### PR TITLE
Infobox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 target/
 .idea/
 *.iml
+.classpath
+.project
+.settings/

--- a/src/main/java/edu/jhu/nlp/wikipedia/InfoBox.java
+++ b/src/main/java/edu/jhu/nlp/wikipedia/InfoBox.java
@@ -20,4 +20,7 @@ public class InfoBox {
 	public String dumpRaw() {
 		return infoBoxWikiText;
 	}
+	public boolean isEmpty() {
+		return infoBoxWikiText.isEmpty();
+	}
 }

--- a/src/main/java/edu/jhu/nlp/wikipedia/InfoBox.java
+++ b/src/main/java/edu/jhu/nlp/wikipedia/InfoBox.java
@@ -3,13 +3,21 @@ package edu.jhu.nlp.wikipedia;
 /**
  * A class abstracting Wiki infobox
  * @author Delip Rao
+ * @author Victor Olivares
  */
 public class InfoBox {
-  String infoBoxWikiText = null;
-  InfoBox(String infoBoxWikiText) {
-    this.infoBoxWikiText = infoBoxWikiText;
-  }
-  public String dumpRaw() {
-    return infoBoxWikiText;
-  }
+	String infoBoxWikiText = null;
+	InfoBox(String infoBoxWikiText) {
+		//to to be the following line
+		//this.infoBoxWikiText = infoBoxWikiText;
+		if (infoBoxWikiText != null){
+			this.infoBoxWikiText = infoBoxWikiText;
+		} else {
+			//set infobox text to empty string
+			this.infoBoxWikiText = new String();
+		}
+	}
+	public String dumpRaw() {
+		return infoBoxWikiText;
+	}
 }

--- a/src/main/java/edu/jhu/nlp/wikipedia/WikiTextParser.java
+++ b/src/main/java/edu/jhu/nlp/wikipedia/WikiTextParser.java
@@ -182,7 +182,8 @@ public class WikiTextParser {
     private InfoBox parseInfoBox() throws WikiTextParserException {
         final String INFOBOX_CONST_STR = "{{Infobox";
         int startPos = wikiText.indexOf(INFOBOX_CONST_STR);
-        if (startPos < 0) return null;
+        //if (startPos < 0) return null;
+        if (startPos < 0) return new InfoBox(null);
         int bracketCount = 2;
         int endPos = startPos + INFOBOX_CONST_STR.length();
         for (; endPos < wikiText.length(); endPos++) {


### PR DESCRIPTION
After a WikiPage.getInfoBox() 
The method InfoBox.dumpRaw() was able to throw java.lang.NullPointerException 
Due to the InfoBox object being referred to would be unknowingly null if an infobox did not exist for the given wikipage. 

Instead of having a null object for infobox, dumpRaw() will return an empty string. 
Also InfoBox now has an isEmpty() method. 

Thus never having an InfoBox object being null unknowingly. 