### PR TITLE
Added timestamp to WikiPage

### DIFF
--- a/src/main/java/edu/jhu/nlp/wikipedia/SAXPageCallbackHandler.java
+++ b/src/main/java/edu/jhu/nlp/wikipedia/SAXPageCallbackHandler.java
@@ -20,6 +20,7 @@ public class SAXPageCallbackHandler extends DefaultHandler {
 	private StringBuilder currentWikitext;
 	private StringBuilder currentTitle;
 	private StringBuilder currentID;
+	private StringBuilder currentTimestamp;
 	private String language = null;
 
 
@@ -42,6 +43,10 @@ public class SAXPageCallbackHandler extends DefaultHandler {
 			insideRevision = true;
 		}
 
+		if (qName.equals("timestamp")) {
+			currentTimestamp = new StringBuilder("");
+		}
+
 	}
 
 	@Override
@@ -49,15 +54,20 @@ public class SAXPageCallbackHandler extends DefaultHandler {
 		if (qName.equals("revision")){
 			insideRevision = false;
 		}
+
 		if (qName.equals("page")){
 			currentPage.setTitle(currentTitle.toString());
 			currentPage.setID(currentID.toString());
 			currentPage.setWikiText(currentWikitext.toString(), language);
 			pageHandler.process(currentPage);
 		}
-		if (qName.equals("mediawiki"))
-		{
+
+		if (qName.equals("mediawiki")) {
 			// TODO hasMoreElements() should now return false
+		}
+
+		if (qName.equals("timestamp")) {
+            currentPage.setTimestamp(currentTimestamp.toString());
 		}
 	}
 
@@ -72,6 +82,9 @@ public class SAXPageCallbackHandler extends DefaultHandler {
 		}
 		else if (currentTag.equals("text")){
 			currentWikitext = currentWikitext.append(ch, start, length);
+		}
+		else if (currentTag.equals("timestamp")) {
+		    currentTimestamp.append(ch, start, length);
 		}
 	}
 }

--- a/src/main/java/edu/jhu/nlp/wikipedia/WikiPage.java
+++ b/src/main/java/edu/jhu/nlp/wikipedia/WikiPage.java
@@ -156,7 +156,8 @@ public class WikiPage {
     }
 
     public void setID(String id) {
-        this.id = id;
+        // Trim to get rid of extraneous whitespace and newline
+        this.id = id.trim();
     }
 
     public String getID() {

--- a/src/main/java/edu/jhu/nlp/wikipedia/WikiPage.java
+++ b/src/main/java/edu/jhu/nlp/wikipedia/WikiPage.java
@@ -15,6 +15,7 @@ public class WikiPage {
     private String title = null;
     private WikiTextParser wikiTextParser = null;
     private String id = null;
+    private String timestamp = null;
     private Language language = null;
     private Pattern disambCatPattern = null; //Pattern.compile("\\("+language.getDisambiguationLabel()+"\\)", Pattern.CASE_INSENSITIVE);
     private Pattern categoryPattern = null; //Pattern.compile( language.getLocalizedCategoryLabel()+ "\\W\\w+", Pattern.CASE_INSENSITIVE);
@@ -162,5 +163,13 @@ public class WikiPage {
 
     public String getID() {
         return id;
+    }
+
+    public void setTimestamp(String timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public String getTimestamp() {
+        return timestamp;
     }
 }

--- a/src/test/java/edu/jhu/nlp/wikipedia/WikiXMLParserTest.java
+++ b/src/test/java/edu/jhu/nlp/wikipedia/WikiXMLParserTest.java
@@ -16,6 +16,7 @@ public class WikiXMLParserTest {
 
                 assertEquals("Isaac Newton", page.getTitle());
                 assertEquals("14627", page.getID());
+                assertEquals("2010-01-04T10:29:28Z", page.getTimestamp());
 
             }
         });


### PR DESCRIPTION
1. Fixed a bug which was causing WikiXMLParserTest to fail.
2. Wrote a small bit of code to also extract the revision timestamp from the XML and included as part of the WikiPage.
3. New code is tested by an `assertEquals` which I added to WikiXMLParserTest.