### PR TITLE
Update WikiTextParser.java

### DIFF
--- a/src/main/java/edu/jhu/nlp/wikipedia/WikiTextParser.java
+++ b/src/main/java/edu/jhu/nlp/wikipedia/WikiTextParser.java
@@ -78,7 +78,7 @@ public class WikiTextParser {
      * Create localized patterns (given the language in the constructor) for redirects, stubs, etc.
      */
     private void createPatterns(){
-        redirectPattern = Pattern.compile("#"+language.getLocalizedRedirectLabel()+"\\s*\\[\\[(.*?)\\]\\]", Pattern.CASE_INSENSITIVE);
+        redirectPattern = Pattern.compile(language.getLocalizedRedirectLabel()+"\\s*\\[\\[(.*?)\\]\\]", Pattern.CASE_INSENSITIVE);
         stubPattern = Pattern.compile("\\-"+language.getLocalizedStubLabel()+"\\}\\}", Pattern.CASE_INSENSITIVE);
         disambiguationPattern = Pattern.compile("\\{\\{"+language.getDisambiguationLabel()+"\\}\\}", Pattern.CASE_INSENSITIVE);
     }


### PR DESCRIPTION
Remove the extra '#' from regex matcher to detect REDIRECT pages. 
The '#' already appears in the JSON file with the language localization.